### PR TITLE
Fix: cast from_user to int in get_users() to avoid BOT_METHOD_INVALID

### DIFF
--- a/plugins/pmfilter.py
+++ b/plugins/pmfilter.py
@@ -1067,7 +1067,7 @@ async def cb_handler(client: Client, query: CallbackQuery):
             }
         }
         cfg = status_configs[key]
-        user = await client.get_users(from_user)
+        user = await client.get_users(int(from_user))
         btn = [[InlineKeyboardButton(cfg["btn_text"], callback_data=f'{cfg["alert_key"]}#{from_user}')]]
         btn2 = [[
             InlineKeyboardButton('ᴊᴏɪɴ ᴄʜᴀɴɴᴇʟ', url=UPDATE_CHNL_LNK),


### PR DESCRIPTION
BOT_METHOD_INVALID / ResolvePhone error, string ID treated as phone number by Pyrogram. this change to avoid this error:
[2026-08-21 10:01:24 AM] ERROR    | plugins.pmfilter:pmfilter:1075 — get_users failed for 6682111015: Telegram says: [400 BOT_METHOD_INVALID] - The specified method cannot be used by bots. (caused by "contacts.ResolvePhone")
Instance is stopping.